### PR TITLE
Body background in CSS not wordpress

### DIFF
--- a/wp-content/themes/mozilla-festival/style.css
+++ b/wp-content/themes/mozilla-festival/style.css
@@ -7,6 +7,10 @@
 
 @import url("../twentyeleven/style.css");
 
+body {
+    background: #F3F0DD url('https://festival.mozillalabs.com/wp-content/uploads/2011/08/stripes.png') repeat top center;
+}
+
 #masthead {
     margin-top: 2.2em;
     padding-right: 2em;


### PR DESCRIPTION
The custom link colours have since been reverted.
