### PR TITLE
Made hash links to each Space more discoverable

### DIFF
--- a/components/space-pathway-profile.jsx
+++ b/components/space-pathway-profile.jsx
@@ -25,7 +25,7 @@ var SpacePathwayProfile = React.createClass({
           <div className="header">
             { this.props.iconPath ? <ImageTag src1x={this.props.iconPath} width="100" /> 
                                   : null}
-            <h1>{this.props.name}</h1>
+            <h1><a href={"#"+id}>{this.props.name}</a></h1>
           </div>
           { this.props.type ? <div className="type">{this.props.type}</div> : null }
           <div className="description">{this.props.description}</div>

--- a/less/components/space-pathway-profile.less
+++ b/less/components/space-pathway-profile.less
@@ -29,6 +29,11 @@
           margin-left: 20px;
         }
       }
+      a {
+        font-weight: inherit;
+        text-transform: none;
+        font-size: inherit;
+      }
     }
     .type {
       font-style: italic;


### PR DESCRIPTION
Fixes #429 

Just a quick fix - clicking on each Space name on https://mozillafestival.org/spaces-and-sessions will give you the hash link to the Space.