### PR TITLE
Remove references to 2016 CFP

### DIFF
--- a/client.jsx
+++ b/client.jsx
@@ -5,8 +5,7 @@ var React = require('react'),
 var routes = (
   <Route>
     <Route name="home" path="/" handler={require('./pages/home.jsx')} />
-    <Route name="proposals" path="/proposals" handler={require('./pages/proposals.jsx')} />
-    <Route name="proposals-extended" path="/proposals-2015" handler={require('./pages/proposals.jsx')} />
+    <Route name="proposals" path="/late-proposals" handler={require('./pages/proposals.jsx')} />
     <Route name="location" path="/location" handler={require('./pages/location.jsx')} />
     <Route name="about" path="/about" handler={require('./pages/about.jsx')} />
     <Route name="contact" path="/contact" handler={require('./pages/contact.jsx')} />

--- a/components/header.jsx
+++ b/components/header.jsx
@@ -23,9 +23,6 @@ var Header = React.createClass({
               <Link to="tickets">Tickets</Link>
             </div>
             <div className="nav-link-container">
-              <Link to="proposals">call for proposals</Link>
-            </div>
-            <div className="nav-link-container">
               <Link to="location">location</Link>
             </div>
             <div className="nav-link-container">

--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -54,9 +54,9 @@ var Home = React.createClass({
           <div>Join us to build, debate, and explore the future of our lives online.</div>
         </HeroUnit>
         <div className="centered content wide">
-          <h1>Submit a Session for MozFest 2016</h1>
-          <p>We invite people from all fields: policy, science, journalism, technology, arts and more. MozFest is for everyone, regardless of your gender, geography, age or language. </p>
-          <Link to="proposals" className="button"><span>Submit a Session</span></Link>
+          <h1>Buy a Ticket for MozFest 2016</h1>
+          <p>Join leaders of the open Web -- artists, activists, educators, scientists, journalists, policy-makers and technologists -- who are building a better internet.</p>
+          <Link to="tickets" className="button"><span>Buy a Ticket</span></Link>
         </div>
         <Footer/>
       </div>

--- a/pages/sessions.jsx
+++ b/pages/sessions.jsx
@@ -19,7 +19,6 @@ var SpacesInfo = [
       <p>21st Century, the relationship between art and technology has grown deeper and more nuanced than ever before. We use technology to create art. We view and share art using new and impressive digital tools. And often, technology itself — from products to Web pages — is art
       </p>
       <p>Join the Digital Arts and Culture Space for workshops, demos, and discussions that unpack the relationship between art, technology, and the Web. We’ll explore how vlogging is becoming an art form of its own; discover how digital tech is making the arts accessible to people with all abilities; ask when code is at its most creative; and understand the role of digital arts in society. Whether you’re a professional artist or a DIY maker, everyone will have an opportunity to create and be inspired.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -34,7 +33,6 @@ var SpacesInfo = [
     (<div>
       <p>Journalism doesn't just tell the story of the Internet — it's part of it. Software like Django, D3, and Backbone has emerged from newsrooms to power some of the most innovative work on the open Web. And reporting entertains and challenges millions of readers online every day, giving them the information they need to engage with their communities.</p>
       <p>In the Journalism Space, we explore how journalism can change our lives, both in person and online. Participants will learn how developers, designers, and data analysts collaborate to cover the most important stories of the day, and how they can contribute to the kind of work that protects the open Web and drives it forward.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -55,7 +53,6 @@ var SpacesInfo = [
     (<div>
       <p>Science and the Web both help us understand the world around us. In the Open Science Space, participants explore, remix, and hack at the intersection of science and the Internet, and learn how the Web is transforming research and discovery.</p>
       <p>We cover topics like open data and research, citizen science, and science communication — all the while learning news skills and tools. We also collaborate on each other’s projects, and our Open Research Accelerator provides one-on-one mentorship for making your project open source. The Open Science Space is open to everyone: We invite hobbyists, researchers, librarians, data scientists, developers, and all others to join us.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -79,7 +76,6 @@ var SpacesInfo = [
     (<div>
       <p>Open Badges are transforming how we recognise and reward learning. These digital credentials showcase and communicate learners’ skills — from HTML to design — in a way that traditional CVs and transcripts cannot.</p>
       <p>Open Badges are taking root around the world, from non-profits to major employers and universities. And the technical infrastructure that makes badges possible is constantly evolving. In the Open Badges Space, we’ll showcase exciting badges projects, hack on and build badge infrastructure, and encourage new partners and networks adopt badges. We’re also plugging Open Badges into other spaces and sessions across MozFest.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -103,7 +99,6 @@ var SpacesInfo = [
     (<div>
       <p>Who do you think should create culture? How do we build a movement to encourage creativity and imagination? If these questions keep you up at night, the open internet movement — and Fuel The Movement Space — needs you!</p>
       <p>We're bringing people together to talk about how current copyright laws aren't equipped for the internet age. Right now, we have a unique opportunity in the European Union to update and reform copyright laws to enhance -- not hinder -- creativity and innovation. Fuel The Movement will help participants explore how these and other laws impact them -- and what YOU can do about it -- through interactive art installations, hands-on workshops, and lightning talks. Participants will walk away energized to support creativity on the open internet.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -127,7 +122,6 @@ var SpacesInfo = [
     (<div>
       <p>The Internet spans many cultures and languages — and so does the Localisation Space.</p>
       <p>This space reflects the diversity of the Web and the people who use it. It’s set up like a marketplace, rich with different colors, smells, and flavours. We’ll explore how people participate in the digital world in a way that reflects their unique culture and identity. Localisation experts and amateurs alike will share localisation tools, discuss their experiences on a multicultural Internet, and explore how we can create a Web that’s truly inclusive of all languages and societies.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -148,7 +142,6 @@ var SpacesInfo = [
     (<div>
       <p>Too often, current-day education systems are prescriptive. Learning is based around certain objectives, like exams. And independent thinking isn’t encouraged.</p>
       <p>In the Youth Zone Space, we’re creating an environment where independent thinking isn’t just encouraged — it’s rewarded. Our space is a sandbox for kids, teens, and adults alike to tinker, hack, build, and play as a means of learning. Sessions will be hands-on and centered around Raspberry Pi and virtual reality, with a focus on the artistry of these tools. We’ll also reimagine what a 21st-century library should look like — a collection of open source tools and activities.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>.</p>
     </div>),
     contacts: [
       {
@@ -166,7 +159,6 @@ var SpacesInfo = [
     (<div>
       <p>Grab your ticket to our carnival of learning! All who enter will gain the most important skills of our age: the ability to read, write and participate in our digital world.</p>
       <p>The Demystify the Web Space invites teachers and learners of all ages to join our funhouse of Web literacy. Embrace the unknown! Experience the thrills! Imagine and share the full potential of the Web with everyone!</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>. We’re looking for sessions that share fun, interactive ways to teach and learn the Web in diverse, inclusive spaces; sessions designed for creative collisions; sessions that inspire people to engage in an openly networked world.</p>
     </div>),
     contacts: [
       {
@@ -190,7 +182,6 @@ var SpacesInfo = [
     (<div>
       <p>As our lives and physical environments become even more connected online, we're faced with dilemmas. Should I allow my personal data to be used if it improves my daily life? Should my everyday objects be online?</p>
       <p>This space will allow makers and learners to explore these dilemmas through a series of interactive experiences and mischievous interventions. Participants might nap on a squishy chair that generates sleep data; cook a snack in a connected kitchen where appliances only sometimes do as you say; and hack on IoT hardware.</p>
-      <p>Have a great session idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>. We're seeking fellow pranksters who want to create memorable moments. We're less interested in traditional sessions and more interested in experiences like dance-offs, exhibits, interactive comic books, and newly-invented sports.</p>
     </div>),
     contacts: [
       {
@@ -217,7 +208,6 @@ var SpacesInfo = [
     (<div>
       <p>MozEx is an art exhibition with a 21st-century twist. Curated by the digital learning teams at both the Tate and the V&A, this space showcases dynamic digital artwork that spans many disciplines and media.</p>
       <p>The MozEx exhibit explores links between art, society, and the digital world. Created by both individual practitioners and cross-disciplinary collaborations, the exhibit will explore the value of art to society through Web literacy, digital inclusion and accessibility, privacy, policy, and hacking.</p>
-      <p>Have a great artwork idea? Head to the <a href="proposals">MozFest Call for Proposals page</a>. We are keen to see submissions that explore the exchange of knowledge and practice with audiences.</p>
     </div>),
     contacts: [
       {


### PR DESCRIPTION
Change URL of proposals route too.

Closes https://github.com/MozillaFoundation/2016.Mozillafestival.org/issues/74, https://github.com/MozillaFoundation/2016.Mozillafestival.org/issues/75, https://github.com/MozillaFoundation/2016.Mozillafestival.org/issues/76

@gvn can you review this this morning so I can deploy at the end of my day? Shouldn't take long.