### PR TITLE
Respect user's DNT setting

### DIFF
--- a/public/ga.js
+++ b/public/ga.js
@@ -1,0 +1,34 @@
+(function() {
+  var _dntStatus = navigator.doNotTrack || navigator.msDoNotTrack;
+  var fxMatch = navigator.userAgent.match(/Firefox\/(\d+)/);
+  var ie10Match = navigator.userAgent.match(/MSIE 10/i);
+  var w8Match = navigator.appVersion.match(/Windows NT 6.2/);
+
+  if (fxMatch && Number(fxMatch[1]) < 32) {
+    _dntStatus = 'Unspecified';
+  } else if (ie10Match && w8Match) {
+    _dntStatus = 'Unspecified';
+  } else {
+    _dntStatus = {
+        '0': 'Disabled',
+        '1': 'Enabled'
+    }[_dntStatus] || 'Unspecified';
+  }
+
+  if (_dntStatus !== 'Enabled') {
+    (function(i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        i[r] = i[r] || function() {
+            (i[r].q = i[r].q || []).push(arguments)
+        }, i[r].l = 1 * new Date();
+        a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+    ga('create', 'UA-35433268-1', 'auto');
+    ga('send', 'pageview');
+  }
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -21,16 +21,7 @@
   <link rel="stylesheet" type="text/css" href='https://css.tito.io/v1'>
   <link rel="stylesheet" type="text/css" href='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.css'>
   <link rel="stylesheet" type="text/css" href="/build/bundle.css">
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-35433268-1', 'auto');
-    ga('send', 'pageview');
-
-  </script>
+  <script src="ga.js"></script>
 </head>
 <body>
   <div id="my-app">


### PR DESCRIPTION
Related to #565, closes #572

This code was originally provided by @cadecairos, verified, and used on [MozFest schedule app](https://github.com/mozilla/mozfest-event-app/blob/64d5c156a20ccb9dc3281ffd99c61f90f04f596e/js/ga-with-do-not-track-check.js) last year. So I grabbed a copy of it and replaced the UA code. I don't have access to MozFest site's GA dashboard but I verified this code by toggling on/off my browser's DNT setting and see if `https://www.google-analytics.com/analytics.js` got injected.