### PR TITLE
Update HTTP to HTTPS & link fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/components/partners.jsx
+++ b/components/partners.jsx
@@ -14,7 +14,7 @@ const PARTNERS_LIST = [
   {
     name: `Code Is Science`,
     logo: `/assets/images/team/partner/partner_code-is-science_grayscale.png`,
-    link: `http://www.codeisscience.com/`
+    link: `https://www.codeisscience.com/`
   },
   {
     name: `Universidade Federal de Alagoas`,
@@ -44,7 +44,7 @@ const PARTNERS_LIST = [
   {
     name: `Pichoun`,
     logo: `/assets/images/team/partner/partner_pichoun_grayscale.png`,
-    link: `http://www.pichoun.fr`
+    link: `https://www.pichoun.fr`
   },
   {
     name: `UAL`,

--- a/pages/location.jsx
+++ b/pages/location.jsx
@@ -44,7 +44,7 @@ var Location = React.createClass({
           '<p>6 Penrose Way</p>' +
           '<p>Greenwich Peninsula</p>' +
           '<p>London SE10 0EW</p>' +
-          '<a href="http://www.ravensbourne.ac.uk/">ravensbourne.ac.uk</a>' +
+          '<a href="https://www.ravensbourne.ac.uk/">ravensbourne.ac.uk</a>' +
           '<p>+44 20 3040 3500</p>' +
         '</div>'
         )
@@ -69,7 +69,7 @@ var Location = React.createClass({
         <div className="white-background">
           <div className="centered content wide">
             <h1>Main Festival Venue</h1>
-            <p>Mozfest 2016 will be held once again in <a href="http://www.ravensbourne.ac.uk/">Ravensbourne</a>, a media campus in the heart of London. Located right next to the O2 arena and North Greenwich tube station, Ravensbourne's nine floors of open work spaces, breakout rooms and cozy corners are ideal for collaboration and creative working.</p>
+            <p>Mozfest 2016 will be held once again in <a href="https://www.ravensbourne.ac.uk/">Ravensbourne</a>, a media campus in the heart of London. Located right next to the O2 arena and North Greenwich tube station, Ravensbourne's nine floors of open work spaces, breakout rooms and cozy corners are ideal for collaboration and creative working.</p>
             <div className="horizontal-rule"></div>
             <h1>How to get there</h1>
             <div className="illustration flip-it">
@@ -102,11 +102,11 @@ var Location = React.createClass({
             </div>
             <div className="illustration-text small">
               <h2>Bus</h2>
-              <p>Eight TfL bus routes operate to and from North Greenwich including three 24 hour bus services. Key destinations include Stratford, Charlton, Greenwich, Lewisham, Woolwich, Eltham, North Kent and Central London. Please visit <a href="http://www.tfl.gov.uk/">www.tfl.gov.uk</a> for timetable information.</p>
+              <p>Eight TfL bus routes operate to and from North Greenwich including three 24 hour bus services. Key destinations include Stratford, Charlton, Greenwich, Lewisham, Woolwich, Eltham, North Kent and Central London. Please visit <a href="https://www.tfl.gov.uk/">www.tfl.gov.uk</a> for timetable information.</p>
               <h2>Docklands Light Railway (DLR)</h2>
               <p>Just one stop via the Jubilee line from Canary Wharf or Canning Town.</p>
               <h2>Thames Clipper</h2>
-              <p>We are a two minute walk from the North Greenwich Pier stop on the Thames Clipper route. Please visit the <a href="http://www.thamesclippers.com/">Thames Clipper website</a> for routes, fares and journey times.</p>
+              <p>We are a two minute walk from the North Greenwich Pier stop on the Thames Clipper route. Please visit the <a href="https://www.thamesclippers.com/">Thames Clipper website</a> for routes, fares and journey times.</p>
             </div>
           </div>
         </div>

--- a/pages/media.jsx
+++ b/pages/media.jsx
@@ -6,7 +6,7 @@ const PAST_COVERAGE = [
   {
     media: `Wired UK`,
     title: `One unhappy year in Trump's America`,
-    link: `http://www.wired.co.uk/article/upvote-17-one-unhappy-year-in-trumps-america`,
+    link: `https://www.wired.co.uk/article/upvote-17-one-unhappy-year-in-trumps-america`,
     date: `November 2017`
   },
   {
@@ -54,7 +54,7 @@ const PAST_COVERAGE = [
   {
     media: `t3n`,
     title: `Wie steht es um die Gesundheit des Internets? Auf Spurensuche beim Mozilla-Festival`,
-    link: `http://t3n.de/news/mozilla-festival-internet-gesundheit-761360/3/`,
+    link: `https://web.archive.org/web/20170112212535/http://t3n.de/news/mozilla-festival-internet-gesundheit-761360/3/`,
     date: `November 2016`
   },
   {
@@ -72,7 +72,7 @@ const PAST_COVERAGE = [
   {
     media: `The Independent`,
     title: `Baroness Kidron interview: ‘Children’s online safety is too vital to leave to Government’`,
-    link: `http://www.independent.co.uk/news/people/profiles/baroness-kidron-interview-children-s-online-safety-is-too-vital-to-leave-to-government-9819862.html`,
+    link: `https://www.independent.co.uk/news/people/profiles/baroness-kidron-interview-children-s-online-safety-is-too-vital-to-leave-to-government-9819862.html`,
     date: `October 2014`
   },
   {

--- a/pages/projects.jsx
+++ b/pages/projects.jsx
@@ -20,7 +20,7 @@ var ProjectPage = React.createClass({
               {projectData.map((project, index)=>{ return <ProjectCard key={index} {...project } />; } )}
             </div>
           </div>
-          <p>See more projects & assets from our network on <a href="http://mzl.la/pulse">Pulse</a>.</p>
+          <p>See more projects & assets from our network on <a href="https://mzl.la/pulse">Pulse</a>.</p>
         </div>
       </div>
     );
@@ -28,4 +28,3 @@ var ProjectPage = React.createClass({
 });
 
 module.exports = ProjectPage;
-

--- a/talks/2017.js
+++ b/talks/2017.js
@@ -147,7 +147,7 @@ module.exports = [
         twitter: `@emilymaynot`,
         pic: `/assets/images/speakers/2017/EmilyMay.jpeg`,
         talkInfoIndex: 8,
-        description: `Emily is the co-founder and executive director of <a href="http://ihollaback.org/" target="_blank">Hollaback!</a>, an <a href="https://www.ashoka.org/fellow/emily-may" target="_blank">Ashoka Fellow</a>, and a <a href="https://www.prime-movers.net/our-fellows/emily-may/" target="_blank">Prime Movers Fellow</a>. In 2005, at the age of 24, she co-founded Hollaback! in New York City, and in 2010 she became its first full-time executive director. Under her leadership, the organization has scaled to over 50 cities in 25 countries, and launched <a href="https://iheartmob.org/" target="_blank">HeartMob</a>, Hollaback!’s platform designed to support people being harassed online.`,
+        description: `Emily is the co-founder and executive director of <a href="https://ihollaback.org/" target="_blank">Hollaback!</a>, an <a href="https://www.ashoka.org/fellow/emily-may" target="_blank">Ashoka Fellow</a>, and a <a href="https://www.prime-movers.net/our-fellows/emily-may/" target="_blank">Prime Movers Fellow</a>. In 2005, at the age of 24, she co-founded Hollaback! in New York City, and in 2010 she became its first full-time executive director. Under her leadership, the organization has scaled to over 50 cities in 25 countries, and launched <a href="https://iheartmob.org/" target="_blank">HeartMob</a>, Hollaback!’s platform designed to support people being harassed online.`,
       }
     ]
   },
@@ -192,7 +192,7 @@ module.exports = [
         twitter: `@NiNanjira`,
         pic: `/assets/images/speakers/2017/NanjiraSambuli.jpeg`,
         talkInfoIndex: 11,
-        description: `Nanjira is the Digital Equality Advocacy Manager at the Web Foundation, where she leads advocacy efforts to promote digital equality in access to and use of the web, with a particular focus on the Foundation’s <a href="http://webfoundation.org/our-work/projects/womens-rights-online/" target="_blank">Women’s Rights Online</a> work.`,
+        description: `Nanjira is the Digital Equality Advocacy Manager at the Web Foundation, where she leads advocacy efforts to promote digital equality in access to and use of the web, with a particular focus on the Foundation’s <a href="https://webfoundation.org/our-work/projects/womens-rights-online/" target="_blank">Women’s Rights Online</a> work.`,
       }
     ]
   },
@@ -206,14 +206,14 @@ module.exports = [
         twitter: `@Anasuyashh`,
         pic: `/assets/images/speakers/2017/AnasuyaSengupta.jpeg`,
         talkInfoIndex: 12,
-        description: `Anasuya Sengupta is co-founder of <a href="http://whoseknowledge.org/" target="_blank">Whose Knowledge</a>? She has led initiatives in India/USA, across the global South, and internationally for over 20 years to amplify voices from the margins in virtual and physical worlds. She is the former Chief Grantmaking Officer at the Wikimedia Foundation and a 2017 Shuttleworth Fellow.`,
+        description: `Anasuya Sengupta is co-founder of <a href="https://whoseknowledge.org/" target="_blank">Whose Knowledge</a>? She has led initiatives in India/USA, across the global South, and internationally for over 20 years to amplify voices from the margins in virtual and physical worlds. She is the former Chief Grantmaking Officer at the Wikimedia Foundation and a 2017 Shuttleworth Fellow.`,
       },
       {
         name: `Siko Bouterse`,
         twitter: `@sikob`,
         pic: `/assets/images/speakers/2017/SikoBouterse.jpeg`,
         talkInfoIndex: 12,
-        description: `Siko Bouterse is co-founder of <a href="http://whoseknowledge.org/" target="_blank">Whose Knowledge</a>? She is former Director of Community Resources at the Wikimedia Foundation, where she led teams and experiments like the Wikipedia Teahouse and Inspire. For over 10 years, she’s been community organizing, localizing and imagining a more plural, emancipatory and open web.`,
+        description: `Siko Bouterse is co-founder of <a href="https://whoseknowledge.org/" target="_blank">Whose Knowledge</a>? She is former Director of Community Resources at the Wikimedia Foundation, where she led teams and experiments like the Wikipedia Teahouse and Inspire. For over 10 years, she’s been community organizing, localizing and imagining a more plural, emancipatory and open web.`,
       }
     ]
   },


### PR DESCRIPTION
Change links to HTTPS when supported.

Found an invalid link and replaced it with the archived version.

Some links weren't changed because the websites didn't support it or had invalid SSL certificates.