### PR TITLE
Schedule page etc

### DIFF
--- a/components/jumbotron.jsx
+++ b/components/jumbotron.jsx
@@ -68,7 +68,7 @@ class Jumbotron extends React.Component {
     </div>;
 
     return (
-      <div className={classNames({"has-video-bg": this.props.videoJumbotron},`jumbotron-container`)}>
+      <div className={classNames({"has-video-bg": this.props.videoJumbotron},`jumbotron-container`, this.props.className)}>
         { this.props.videoJumbotron && this.renderVideoJumbotron() }
         <div className="jumbotron d-flex flex-column" style={{ backgroundImage: backgroundImages }}>
           <NavBar />

--- a/components/notification-bar.jsx
+++ b/components/notification-bar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 class NotificationBar extends React.Component {
   constructor(props) {
@@ -8,16 +9,24 @@ class NotificationBar extends React.Component {
   }
 
   render() {
-    return (
-      <div className={classNames(`notification-bar p-2 text-center`, this.props.className)}>
+    let classnames = classNames(`notification-bar p-2 text-center`, this.props.className, { "hyperlinked": this.props.to });
+    let barInner = this.props.children;
+
+    if (this.props.to) {
+      barInner = <Link to={this.props.to}>
         { this.props.children }
-      </div>
-    );
+      </Link>;
+    }
+
+    return <div className={classnames}>
+      { barInner }
+    </div>;
   }
 }
 
 NotificationBar.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  to: PropTypes.string
 };
 
 export default NotificationBar;

--- a/less/components/jumbotron.less
+++ b/less/components/jumbotron.less
@@ -1,3 +1,13 @@
+.jumbotron-container {
+  &.short {
+    .jumbotron {
+      @media screen and (min-width: 768px) {
+        min-height: 300px;
+      }
+    }
+  }
+}
+
 .jumbotron {
   padding-top: 20px;
   padding-bottom: 20px;

--- a/less/components/notification-bar.less
+++ b/less/components/notification-bar.less
@@ -7,9 +7,19 @@
   color: white;
   background: linear-gradient(to right, @blue, @pink);
 
+  &.hyperlinked {
+    a {
+      color: white;
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+
   .emphasized {
     font-weight: 600;
     font-style: normal;
+    letter-spacing: 0.5px;
   }
 
   .emphasized + .emphasized {
@@ -21,5 +31,11 @@
         padding-right: 0.5rem;
       }
     }
+  }
+
+  .light {
+    font-style: italic;
+    font-weight: 300;
+    color: white;
   }
 }

--- a/less/pages/home.less
+++ b/less/pages/home.less
@@ -20,8 +20,6 @@
         padding-bottom: 100px;
       }
     }
-
-    padding-bottom: 30px;
   }
 
   .content {

--- a/less/pages/home.less
+++ b/less/pages/home.less
@@ -20,6 +20,8 @@
         padding-bottom: 100px;
       }
     }
+
+    padding-bottom: 30px;
   }
 
   .content {

--- a/less/shared.less
+++ b/less/shared.less
@@ -56,7 +56,8 @@ a.btn:hover {
   }
 }
 
-.btn-arrow {
+.btn-arrow,
+.content .btn-arrow {
   display: inline-block;
   position: relative;
   color: #fff;

--- a/less/shared.less
+++ b/less/shared.less
@@ -56,6 +56,52 @@ a.btn:hover {
   }
 }
 
+.btn-arrow {
+  display: inline-block;
+  position: relative;
+  color: #fff;
+  overflow: hidden;
+  backface-visibility: hidden;
+  vertical-align: baseline;
+  border-width: 0;
+
+  cursor: pointer;
+  transition: all 0.3s ease 0s;
+  &:before {
+    position: absolute;
+    left: -100%;
+    top: 0;
+    content: url(/assets/images/right-arrow.svg);
+    height: 100%;
+    width: 100%;
+    line-height: 1.25;
+    font-size: 180%;
+    transition: all 0.3s ease 0s;
+  }
+  span {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    transition: all 0.3s ease 0s;
+  }
+  &:hover {
+    &:before {
+      left: 2px;
+    }
+    span {
+      transform: translateX(200%);
+    }
+  }
+  &:active {
+    top: 2px;
+    background: lighten(@pink, 10%)
+  }
+  &.full-width {
+    width: 100%;
+  }
+}
+
 .confined-width-header {
   width: 100%;
   max-width: 550px;
@@ -93,52 +139,6 @@ li.no-bullet {
     height: 1px;
     margin: 45px 0 20px;
   }
-
-  .btn-arrow {
-    display: inline-block;
-    position: relative;
-    color: #fff;
-    overflow: hidden;
-    backface-visibility: hidden;
-    vertical-align: baseline;
-    border-width: 0;
-
-    cursor: pointer;
-    transition: all 0.3s ease 0s;
-    &:before {
-      position: absolute;
-      left: -100%;
-      top: 0;
-      content: url(/assets/images/right-arrow.svg);
-      height: 100%;
-      width: 100%;
-      line-height: 1.25;
-      font-size: 180%;
-      transition: all 0.3s ease 0s;
-    }
-    span {
-      display: inline-block;
-      width: 100%;
-      height: 100%;
-      backface-visibility: hidden;
-      transition: all 0.3s ease 0s;
-    }
-    &:hover {
-      &:before {
-        left: 2px;
-      }
-      span {
-        transform: translateX(200%);
-      }
-    }
-    &:active {
-      top: 2px;
-      background: lighten(@pink, 10%)
-    }
-    &.full-width {
-      width: 100%;
-    }
-  }
   h1 {
     color: @blue;
     font-weight: 300;
@@ -149,6 +149,9 @@ li.no-bullet {
     color: @blue;
     font-weight: 600;
     letter-spacing: 0;
+  }
+  h6 {
+    color: @blue;
   }
   p {
     margin: 23px 0;

--- a/main.jsx
+++ b/main.jsx
@@ -10,6 +10,7 @@ import TicketsPage from './pages/tickets.jsx';
 import NotFound from './pages/not-found.jsx';
 import FringePage from './pages/fringe-events/fringe-events.jsx';
 import HousePage from './pages/house.jsx';
+import SchedulePage from './pages/schedule.jsx';
 import ContactPage from './pages/contact.jsx';
 import Footer from './components/footer.jsx';
 
@@ -33,6 +34,7 @@ const Routes = () => (
     <Route exact path="/fringe" component={FringePage} />
     <Route path="/fringe/success" component={require(`./pages/fringe-events/fringe-event-add-success.jsx`)} />
     <Route path="/tickets" component={TicketsPage} />
+    <Route path="/schedule" component={SchedulePage} />
     <Route path="/media" component={require(`./pages/media.jsx`)} />
     <Route exact path="/speakers" component={require(`./pages/speakers.jsx`)} />
     <Route path="/speakers/:tab" component={require(`./pages/speakers.jsx`)} />

--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
+import NotificationBar from '../components/notification-bar.jsx';
 import Jumbotron from '../components/jumbotron.jsx';
 import SpeakersPromo from '../components/speakers-promo.jsx';
 
@@ -37,14 +38,20 @@ class Home extends React.Component {
   render() {
     return (
       <div className={classNames({"has-video-takeover": this.state.videoTakeover}, `home-page`)}>
+        <NotificationBar to="/schedule">
+          <span className="emphasized">The MozFest 2018 schedule is now live!</span> <span className="light">View it here.</span>
+        </NotificationBar>
         <Jumbotron className="home-jumbotron"
           image=""
           image2x=""
-          videoJumbotron={true}
+          videoJumbotron={false}
           toggleVideoTakeover={() => this.handlePlayVideoClick()}
         >
           <h1 className="highlight">Where Web Meets World</h1>
           <p className="mb-0">A seven day celebration for, by, and about people who love the internet, showcasing world-changing ideas and technology through workshops, talks, and interactive sessions.</p>
+          <div>
+            <Link to="/schedule" className="btn btn-arrow my-5"><span>View the schedule</span></Link>
+          </div>
         </Jumbotron>
         <div className="white-background shift-up">
           <div className="content wide centered shift-up pt-4">

--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -39,19 +39,16 @@ class Home extends React.Component {
     return (
       <div className={classNames({"has-video-takeover": this.state.videoTakeover}, `home-page`)}>
         <NotificationBar to="/schedule">
-          <span className="emphasized">The MozFest 2018 schedule is now live!</span> <span className="light">View it here.</span>
+          <div><span className="emphasized">The MozFest 2018 schedule is now live!</span> <span className="light">View it here.</span></div>
         </NotificationBar>
         <Jumbotron className="home-jumbotron"
           image=""
           image2x=""
-          videoJumbotron={false}
+          videoJumbotron={true}
           toggleVideoTakeover={() => this.handlePlayVideoClick()}
         >
           <h1 className="highlight">Where Web Meets World</h1>
           <p className="mb-0">A seven day celebration for, by, and about people who love the internet, showcasing world-changing ideas and technology through workshops, talks, and interactive sessions.</p>
-          <div>
-            <Link to="/schedule" className="btn btn-arrow my-5"><span>View the schedule</span></Link>
-          </div>
         </Jumbotron>
         <div className="white-background shift-up">
           <div className="content wide centered shift-up pt-4">

--- a/pages/schedule.jsx
+++ b/pages/schedule.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Jumbotron from '../components/jumbotron.jsx';
+import generateHelmet from '../lib/helmet.jsx';
+
+class SchedulePage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // this.pageMetaDescription = `Please email festival@mozilla.org with your questions and suggestions!`;
+  }
+
+  render() {
+    return (
+      <div className="schedule-page">
+        {generateHelmet(this.pageMetaDescription)}
+        <Jumbotron image="/assets/images/hero/contact.jpg"
+          image2x="/assets/images/hero/contact.jpg"
+          className="short"
+        >
+          <h1 className="highlight">Schedule</h1>
+        </Jumbotron>
+        <div className="white-background">
+          <div className="content wide">
+            <div className="container-fluid">
+              <div className="row text-center">
+                <div className="col-12">
+                  <h1>MozFest 2018 Schedule</h1>
+                </div>
+              </div>
+              <div className="row text-center">
+                <div className="col-12 my-5">
+                  <a href="https://guidebook.com/guide/147793/" className="btn btn-arrow"><span>View Online Schedule</span></a>
+                </div>
+                <div className="col-12 mb-5">
+                  <h6>Get the Guidebook App</h6>
+                  <a className="mx-1" href="https://itunes.apple.com/us/app/id428713847">
+                    <img src="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge.png" srcset="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge.png 1x, https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge@2x.png 2x" alt="Download on the app store" height="40" />
+                  </a>
+                  <a className="mx-1" href="https://play.google.com/store/apps/details?id=com.guidebook.android">
+                    <img class="sc-eTuwsz ycaOz" src="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge.png" srcset="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge.png 1x, https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge@2x.png 2x" alt="Download on the play store" height="40" />
+                  </a>
+                </div>
+              </div>
+              <div className="row">
+                <div className="col-12">
+                  <p>Celebrate what you love about the web, and discover new ways to make the internet a better, healthier place.</p>
+
+                  <p>This year we have over 300 sessions taking place over MozFest weekend, not to mention the 18 events you can attend at MozFest House.</p>
+                  <p> We are using Guidebook as our scheduling tool to share the sessions and bios of facilitators, and to help you decide how to spend your time over the weekend at Ravensbourne.</p>
+
+                  <p>You can access Guidebook by downloading the app to your phone, or by visiting the schedule on your browser. If you don't wish to use Guidebook, please note we will be displaying the schedule at info booths on each floor over the festival weekend.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SchedulePage;

--- a/pages/schedule.jsx
+++ b/pages/schedule.jsx
@@ -5,8 +5,6 @@ import generateHelmet from '../lib/helmet.jsx';
 class SchedulePage extends React.Component {
   constructor(props) {
     super(props);
-
-    // this.pageMetaDescription = `Please email festival@mozilla.org with your questions and suggestions!`;
   }
 
   render() {
@@ -34,10 +32,10 @@ class SchedulePage extends React.Component {
                 <div className="col-12 mb-5">
                   <h6>Get the Guidebook App</h6>
                   <a className="mx-1" href="https://itunes.apple.com/us/app/id428713847">
-                    <img src="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge.png" srcset="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge.png 1x, https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge@2x.png 2x" alt="Download on the app store" height="40" />
+                    <img src="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge.png" srcSet="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge.png 1x, https://s3.amazonaws.com/coverpage.guidebook.com/production/img_app_store_badge@2x.png 2x" alt="Download on the app store" height="40" />
                   </a>
                   <a className="mx-1" href="https://play.google.com/store/apps/details?id=com.guidebook.android">
-                    <img class="sc-eTuwsz ycaOz" src="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge.png" srcset="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge.png 1x, https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge@2x.png 2x" alt="Download on the play store" height="40" />
+                    <img src="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge.png" srcSet="https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge.png 1x, https://s3.amazonaws.com/coverpage.guidebook.com/production/img_google_play_badge@2x.png 2x" alt="Download on the play store" height="40" />
                   </a>
                 </div>
               </div>
@@ -48,7 +46,7 @@ class SchedulePage extends React.Component {
                   <p>This year we have over 300 sessions taking place over MozFest weekend, not to mention the 18 events you can attend at MozFest House.</p>
                   <p> We are using Guidebook as our scheduling tool to share the sessions and bios of facilitators, and to help you decide how to spend your time over the weekend at Ravensbourne.</p>
 
-                  <p>You can access Guidebook by downloading the app to your phone, or by visiting the schedule on your browser. If you don't wish to use Guidebook, please note we will be displaying the schedule at info booths on each floor over the festival weekend.</p>
+                  <p>Download the Guidebook app on your phone to view the schedule. Once you download it, search for <strong>Mozilla Festival 2018</strong> in the app and add it to get the schedule. You can also view the <a href="https://guidebook.com/guide/147793/schedule/" target="_blank">schedule online</a>. If you don't wish to use Guidebook, please note that we will be displaying the schedule at info booths on each floor over the festival weekend.</p>
                 </div>
               </div>
             </div>

--- a/server.js
+++ b/server.js
@@ -224,7 +224,7 @@ function renderPage(appHtml, reactHelmet) {
               <link rel="apple-touch-icon" type="image/png" sizes="120x120" href="/assets/images/favicon/apple-touch-icon-120x120@2x.png" />
               <link rel="apple-touch-icon" type="image/png" sizes="152x152" href="/assets/images/favicon/apple-touch-icon-152x152@2x.png" />
               <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
-              <link href="https://fonts.googleapis.com/css?family=Zilla+Slab|Zilla+Slab+Highlight" rel="stylesheet">
+              <link href="https://fonts.googleapis.com/css?family=Zilla+Slab+Highlight:400,700|Zilla+Slab:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
               <link rel="stylesheet" type="text/css" href="/vendor/css/font-awesome.min.css">
               <link rel="stylesheet" type="text/css" href="/vendor/css/mofo-bootstrap.css"/>
               <link rel="stylesheet" type="text/css" href="/build/style.css">


### PR DESCRIPTION
Related to #1059

Missing two things from designers / copy

- [ ] ~~home page banner image~~ we are not doing this anymore
- [x] on /schedule page - Currently we only have instructions on how to install the Guidebook app. There are a ton of schedules from other events on that app. We need to add instruction on **how to find "Mozilla Festival 2018" schedule on the Guidebook app**.